### PR TITLE
Added BLEND_COLOR, Changed TRUE and FALSE to be GLboolean

### DIFF
--- a/src/gl/lib.rs
+++ b/src/gl/lib.rs
@@ -85,6 +85,9 @@ pub mod types {
     pub type GLvdpauSurfaceNV = GLintptr;
 }
 
+pub static FALSE: GLboolean = 0;
+pub static TRUE: GLboolean = 1;
+
 pub static DEPTH_BUFFER_BIT: GLenum = 0x00000100;
 pub static STENCIL_BUFFER_BIT: GLenum = 0x00000400;
 pub static COLOR_BUFFER_BIT: GLenum = 0x00004000;
@@ -119,11 +122,9 @@ pub static GEOMETRY_SHADER_BIT: GLenum = 0x00000004;
 pub static TESS_CONTROL_SHADER_BIT: GLenum = 0x00000008;
 pub static TESS_EVALUATION_SHADER_BIT: GLenum = 0x00000010;
 pub static ALL_SHADER_BITS: GLenum = 0xFFFFFFFF;
-pub static FALSE: GLenum = 0;
 pub static NO_ERROR: GLenum = 0;
 pub static ZERO: GLenum = 0;
 pub static NONE: GLenum = 0;
-pub static TRUE: GLenum = 1;
 pub static ONE: GLenum = 1;
 pub static INVALID_INDEX: GLenum = 0xFFFFFFFF;
 pub static TIMEOUT_IGNORED: GLenum = 0xFFFFFFFFFFFFFFFF;


### PR DESCRIPTION
BLEND_COLOR can used as glGet parameter to get the value set with glBlendColor:
http://www.opengl.org/sdk/docs/man/xhtml/glBlendColor.xml

TRUE and FALSE are used exactly where GLboolean type is (Is*, *Mask, and others), so turning it to GLboolean makes working with these functions smooth and nice.
