### PR TITLE
Make examples be compiled correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ examples: $(EXAMPLES:%=$(EXAMPLES_DIR)/%)
 
 $(EXAMPLES_DIR)/% : $(EXAMPLES:%=src/examples/%/main.rs)
 	@mkdir -p $(EXAMPLES_DIR)
-	@echo $(RUSTC) -L/usr/lib -L/usr/local/lib -Llib --out-dir=$(EXAMPLES_DIR) -O src/examples/$*/main.rs
+	$(RUSTC) -L/usr/lib -L/usr/local/lib -o $(EXAMPLES_DIR)/$* -O -C link-args="-lglfw" src/examples/$*/main.rs
 
 gen: src/gen/main.rs
 	@mkdir -p bin

--- a/src/examples/basic/main.rs
+++ b/src/examples/basic/main.rs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate glfw;
+extern crate native;
+extern crate glfw = "glfw-rs";
 extern crate gl;
-
-#[link_args="-lglfw"] extern {}
 
 #[start]
 fn start(argc: int, argv: **u8) -> int {
-    std::rt::start_on_main_thread(argc, argv, main)
+    native::start(argc, argv, main)
 }
 
 fn main() {

--- a/src/examples/triangle/main.rs
+++ b/src/examples/triangle/main.rs
@@ -16,7 +16,8 @@
 #[feature(globs)];
 #[feature(macro_rules)];
 
-extern crate glfw;
+extern crate native;
+extern crate glfw = "glfw-rs";
 extern crate gl;
 
 use std::cast;
@@ -26,8 +27,6 @@ use std::mem;
 use std::vec;
 
 use gl::types::*;
-
-#[link_args="-lglfw"] extern {}
 
 // Vertex data
 static VERTEX_DATA: [GLfloat, ..6] = [
@@ -53,7 +52,7 @@ static FS_SRC: &'static str =
 
 #[start]
 fn start(argc: int, argv: **u8) -> int {
-    std::rt::start_on_main_thread(argc, argv, main)
+    native::start(argc, argv, main)
 }
 
 fn compile_shader(src: &str, ty: GLenum) -> GLuint {
@@ -72,8 +71,8 @@ fn compile_shader(src: &str, ty: GLenum) -> GLuint {
             let mut len = 0;
             gl::GetShaderiv(shader, gl::INFO_LOG_LENGTH, &mut len);
             let mut buf = vec::from_elem(len as uint - 1, 0u8);     // subtract 1 to skip the trailing null character
-            gl::GetShaderInfoLog(shader, len, ptr::mut_null(), vec::raw::to_mut_ptr(buf) as *mut GLchar);
-            fail!(str::raw::from_utf8(buf));
+            gl::GetShaderInfoLog(shader, len, ptr::mut_null(), buf.as_mut_ptr() as *mut GLchar);
+            fail!(str::raw::from_utf8(buf).to_owned());
         }
     }
     shader
@@ -94,8 +93,8 @@ fn link_program(vs: GLuint, fs: GLuint) -> GLuint {
             let mut len: GLint = 0;
             gl::GetProgramiv(program, gl::INFO_LOG_LENGTH, &mut len);
             let mut buf = vec::from_elem(len as uint - 1, 0u8);     // subtract 1 to skip the trailing null character
-            gl::GetProgramInfoLog(program, len, ptr::mut_null(), vec::raw::to_mut_ptr(buf) as *mut GLchar);
-            fail!(str::raw::from_utf8(buf));
+            gl::GetProgramInfoLog(program, len, ptr::mut_null(), buf.as_mut_ptr() as *mut GLchar);
+            fail!(str::raw::from_utf8(buf).to_owned());
         }
     }
     program


### PR DESCRIPTION
Why is the command only printed?
I found this very confusing because it seems like the examples were built correctly,
while actually nothing happened.

Note that I removed the -Llib flag because that caused the compiler to crash if you have installed the library because of [this issue](https://github.com/mozilla/rust/issues/11195).
Currently, getting the examples to work is a bit of a pain:

Prerequisites:
- Do not install rustc in /usr/local/lib/
- Change the RUSTC variable to the path to your rustc binary
- Make sure to have installed glfw-rs

Commands:
- make
- sudo make install
- make examples
