### PR TITLE
Add makefile targets for previous versions (gl21, gl30, gl31, gl33)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ $(EXAMPLES_DIR)/% : $(EXAMPLES:%=src/examples/%/main.rs)
 
 gen: src/gen/main.rs
 	@mkdir -p bin
-	$(RUSTC) -L/usr/lib -L/usr/local/lib -Llib -O $? -o bin/glrsgen
+	$(RUSTC) -O -Llib/ $? -o bin/glrsgen
 
 install: lib
 	@mkdir -p $(LIB_INSTALL_DIR)
@@ -95,6 +95,7 @@ clean:
 .PHONY: \
 	all \
 	lib \
+	gen \
 	check \
 	doc \
 	install \

--- a/src/gen/main.rs
+++ b/src/gen/main.rs
@@ -13,13 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[crate_id = "github.com/bjz/gl-rs#gen:0.1"];
-#[comment = "OpenGL function loader generator."];
-#[license = "ASL2"];
+#![crate_id = "github.com/bjz/gl-rs#gen:0.1"]
+#![comment = "OpenGL function loader generator."]
+#![license = "ASL2"]
 
-#[feature(globs)];
-#[feature(macro_rules)];
-#[feature(phase)];
+#![feature(globs)]
+#![feature(macro_rules)]
+#![feature(phase)]
 
 //! Requires libxml2
 //!
@@ -237,13 +237,13 @@ impl<'a, W: Writer> Generator<'a, W> {
         self.write_line("// limitations under the License.");
         self.write_line("");
         let ns = self.ns.to_str();
-        self.write_line(format!(r#"\#[crate_id = "github.com/bjz/gl-rs\#{}:0.1"];"#, ns));
-        self.write_line("#[comment = \"An OpenGL function loader.\"];");
-        self.write_line("#[license = \"ASL2\"];");
-        self.write_line("#[crate_type = \"lib\"];");
+        self.write_line(format!(r#"\#![crate_id = "github.com/bjz/gl-rs\#{}:0.1"]"#, ns));
+        self.write_line("#![comment = \"An OpenGL function loader.\"]");
+        self.write_line("#![license = \"ASL2\"]");
+        self.write_line("#![crate_type = \"lib\"]");
         self.write_line("");
-        self.write_line("#[feature(macro_rules)];");
-        self.write_line("#[feature(globs)];");
+        self.write_line("#![feature(macro_rules)]");
+        self.write_line("#![feature(globs)]");
         self.write_line("");
         self.write_line("use std::libc::*;");
         self.write_line("use self::types::*;");

--- a/src/gen/registry.rs
+++ b/src/gen/registry.rs
@@ -334,12 +334,12 @@ impl<'a> RegistryBuilder {
 
                 // add enum namespace
                 StartElement(ref s, _) if s.as_slice() == "enums" => {
-                    registry.enums.extend(&mut self.consume_enums().move_iter())
+                    registry.enums.extend(self.consume_enums().move_iter())
                 }
 
                 // add command namespace
                 StartElement(ref s, _) if s.as_slice() == "commands" => {
-                    registry.cmds.extend(&mut self.consume_cmds().move_iter());
+                    registry.cmds.extend(self.consume_cmds().move_iter());
                 }
 
                 StartElement(ref s, ref atts) if s.as_slice() == "feature" => {
@@ -382,8 +382,8 @@ impl<'a> RegistryBuilder {
                     // XXX: verify that the string comparison with <= actually works as desired
                     if f.api == filter.api && f.number <= filter.version {
                         for req in f.requires.iter() {
-                            desired_enums.extend(&mut req.enums.iter().map(|x| x.clone()));
-                            desired_cmds.extend(&mut req.commands.iter().map(|x| x.clone()));
+                            desired_enums.extend(req.enums.iter().map(|x| x.clone()));
+                            desired_cmds.extend(req.commands.iter().map(|x| x.clone()));
                         }
                     }
                     if f.number == filter.version {
@@ -420,8 +420,8 @@ impl<'a> RegistryBuilder {
                             fail!("Requested {}, which doesn't support the {} API", ext.name, filter.api);
                         }
                         for req in ext.requires.iter() {
-                            desired_enums.extend(&mut req.enums.iter().map(|x| x.clone()));
-                            desired_cmds.extend(&mut req.commands.iter().map(|x| x.clone()));
+                            desired_enums.extend(req.enums.iter().map(|x| x.clone()));
+                            desired_cmds.extend(req.commands.iter().map(|x| x.clone()));
                         }
                     }
                 }

--- a/src/gl/gl21.rs
+++ b/src/gl/gl21.rs
@@ -13,13 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[crate_id = "github.com/bjz/gl-rs#gl:0.1"];
-#[comment = "An OpenGL function loader."];
-#[license = "ASL2"];
-#[crate_type = "lib"];
+#![crate_id = "github.com/bjz/gl-rs#gl:0.1"]
+#![comment = "An OpenGL function loader."]
+#![license = "ASL2"]
+#![crate_type = "lib"]
 
-#[feature(macro_rules)];
-#[feature(globs)];
+#![feature(macro_rules)]
+#![feature(globs)]
 
 use std::libc::*;
 use self::types::*;

--- a/src/gl/gl30.rs
+++ b/src/gl/gl30.rs
@@ -13,13 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[crate_id = "github.com/bjz/gl-rs#gl:0.1"];
-#[comment = "An OpenGL function loader."];
-#[license = "ASL2"];
-#[crate_type = "lib"];
+#![crate_id = "github.com/bjz/gl-rs#gl:0.1"]
+#![comment = "An OpenGL function loader."]
+#![license = "ASL2"]
+#![crate_type = "lib"]
 
-#[feature(macro_rules)];
-#[feature(globs)];
+#![feature(macro_rules)]
+#![feature(globs)]
 
 use std::libc::*;
 use self::types::*;

--- a/src/gl/gl31.rs
+++ b/src/gl/gl31.rs
@@ -13,13 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[crate_id = "github.com/bjz/gl-rs#gl:0.1"];
-#[comment = "An OpenGL function loader."];
-#[license = "ASL2"];
-#[crate_type = "lib"];
+#![crate_id = "github.com/bjz/gl-rs#gl:0.1"]
+#![comment = "An OpenGL function loader."]
+#![license = "ASL2"]
+#![crate_type = "lib"]
 
-#[feature(macro_rules)];
-#[feature(globs)];
+#![feature(macro_rules)]
+#![feature(globs)]
 
 use std::libc::*;
 use self::types::*;

--- a/src/gl/gl33.rs
+++ b/src/gl/gl33.rs
@@ -13,13 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[crate_id = "github.com/bjz/gl-rs#gl:0.1"];
-#[comment = "An OpenGL function loader."];
-#[license = "ASL2"];
-#[crate_type = "lib"];
+#![crate_id = "github.com/bjz/gl-rs#gl:0.1"]
+#![comment = "An OpenGL function loader."]
+#![license = "ASL2"]
+#![crate_type = "lib"]
 
-#[feature(macro_rules)];
-#[feature(globs)];
+#![feature(macro_rules)]
+#![feature(globs)]
 
 use std::libc::*;
 use self::types::*;

--- a/src/gl/lib.rs
+++ b/src/gl/lib.rs
@@ -13,13 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[crate_id = "github.com/bjz/gl-rs#gl:0.1"];
-#[comment = "An OpenGL function loader."];
-#[license = "ASL2"];
-#[crate_type = "lib"];
+#![crate_id = "github.com/bjz/gl-rs#gl:0.1"]
+#![comment = "An OpenGL function loader."]
+#![license = "ASL2"]
+#![crate_type = "lib"]
 
-#[feature(macro_rules)];
-#[feature(globs)];
+#![feature(macro_rules)]
+#![feature(globs)]
 
 use std::libc::*;
 use self::types::*;
@@ -1114,6 +1114,7 @@ pub static DOUBLE_MAT3x2: GLenum = 0x8F4B;
 pub static DOUBLE_MAT3x4: GLenum = 0x8F4C;
 pub static DOUBLE_MAT4x2: GLenum = 0x8F4D;
 pub static DOUBLE_MAT4x3: GLenum = 0x8F4E;
+pub static VERTEX_BINDING_BUFFER: GLenum = 0x8F4F;
 pub static R8_SNORM: GLenum = 0x8F94;
 pub static RG8_SNORM: GLenum = 0x8F95;
 pub static RGB8_SNORM: GLenum = 0x8F96;
@@ -1722,7 +1723,7 @@ pub static NUM_SAMPLE_COUNTS: GLenum = 0x9380;
 #[inline] pub fn RenderbufferStorageMultisample(target: GLenum, samples: GLsizei, internalformat: GLenum, width: GLsizei, height: GLsizei) { unsafe { (storage::RenderbufferStorageMultisample.f)(target, samples, internalformat, width, height) } }
 #[inline] pub fn ResumeTransformFeedback() { unsafe { (storage::ResumeTransformFeedback.f)() } }
 #[inline] pub fn SampleCoverage(value: GLfloat, invert: GLboolean) { unsafe { (storage::SampleCoverage.f)(value, invert) } }
-#[inline] pub fn SampleMaski(index: GLuint, mask: GLbitfield) { unsafe { (storage::SampleMaski.f)(index, mask) } }
+#[inline] pub fn SampleMaski(maskNumber: GLuint, mask: GLbitfield) { unsafe { (storage::SampleMaski.f)(maskNumber, mask) } }
 #[inline] pub unsafe fn SamplerParameterIiv(sampler: GLuint, pname: GLenum, param: *GLint) { (storage::SamplerParameterIiv.f)(sampler, pname, param) }
 #[inline] pub unsafe fn SamplerParameterIuiv(sampler: GLuint, pname: GLenum, param: *GLuint) { (storage::SamplerParameterIuiv.f)(sampler, pname, param) }
 #[inline] pub fn SamplerParameterf(sampler: GLuint, pname: GLenum, param: GLfloat) { unsafe { (storage::SamplerParameterf.f)(sampler, pname, param) } }
@@ -2317,7 +2318,7 @@ mod storage {
     fn_ptr!(fn RenderbufferStorageMultisample(target: GLenum, samples: GLsizei, internalformat: GLenum, width: GLsizei, height: GLsizei))
     fn_ptr!(fn ResumeTransformFeedback())
     fn_ptr!(fn SampleCoverage(value: GLfloat, invert: GLboolean))
-    fn_ptr!(fn SampleMaski(index: GLuint, mask: GLbitfield))
+    fn_ptr!(fn SampleMaski(maskNumber: GLuint, mask: GLbitfield))
     fn_ptr!(fn SamplerParameterIiv(sampler: GLuint, pname: GLenum, param: *GLint))
     fn_ptr!(fn SamplerParameterIuiv(sampler: GLuint, pname: GLenum, param: *GLuint))
     fn_ptr!(fn SamplerParameterf(sampler: GLuint, pname: GLenum, param: GLfloat))


### PR DESCRIPTION
`make install` doesn't work with previous versions, same with `make doc`.

But at least it's easier for anyone wanting to use the makefiles with older OpenGL versions.
