### PR TITLE
Added makefile targets for previous versions (Attempt 2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,15 @@ SRC_DIR             = src
 TEST_DIR            = test
 LIB_FILE            = $(SRC_DIR)/gl/lib.rs
 
+# Generated previous OpenGL versions.
+VERSIONS            = 21 30 31 32 33
+
+define VERSION_LIB_FILES
+VERSION_LIB_FILES_$(1)   := $(SRC_DIR)/gl/gl$(1).rs
+endef
+
+$(foreach vers,$(VERSIONS),$(eval $(call VERSION_LIB_FILES,$(vers))))
+
 CRATE_NAME          = $(shell $(RUSTC) --crate-name $(LIB_FILE))
 CRATE_FILES         = $(shell $(RUSTC) --crate-file-name $(LIB_FILE))
 
@@ -40,6 +49,15 @@ $(CRATE_FILES): $(LIB_FILE)
 	@mkdir -p $(LIB_DIR)
 	$(RUSTC) --out-dir=$(LIB_DIR) -O $(LIB_FILE)
 
+# Targets for previous OpenGL versions
+define TARGET_CRATES
+lib-$(1): $(VERSION_LIB_FILES_$(1))
+	@mkdir -p $(LIB_DIR)
+	$(RUSTC) --out-dir=$(LIB_DIR) -O $(VERSION_LIB_FILES_$(1))
+endef
+
+$(foreach vers,$(VERSIONS),$(eval $(call TARGET_CRATES,$(vers))))	
+	
 check:
 	@mkdir -p $(TEST_DIR)
 	$(RUSTC) --out-dir=$(TEST_DIR) --test $(LIB_FILE)


### PR DESCRIPTION
I put it in a new branch this time to stop myself causing issues with git.

Adds makefiles targets for gl21, gl30, gl31, gl32, and gl33.
