### PR TITLE
Fix for latest Rust, and include+fix #54

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,8 @@ $(EXAMPLE_FILES): lib examples-dir examples-deps
 examples: $(EXAMPLE_FILES)
 
 gen-deps:
+	@git submodule init
+	@git submodule update
 	make lib -C $(DEPS_DIR)/sax-rs
 
 gen: gen-deps

--- a/src/gen/registry.rs
+++ b/src/gen/registry.rs
@@ -607,7 +607,7 @@ impl<'a> RegistryBuilder {
 
     fn consume_binding(&self, group: Option<~str>) -> Binding {
         // consume type
-        let mut ty = ~"";
+        let mut ty = StrBuf::new();
         loop {
             match self.recv() {
                 Characters(ch) => ty.push_str(ch),
@@ -622,7 +622,7 @@ impl<'a> RegistryBuilder {
         self.expect_end_element("name");
         Binding {
             ident: ident,
-            ty: ty,
+            ty: ty.into_owned(),
             group: group,
         }
     }


### PR DESCRIPTION
One ~str needed to be changed to a StrBuf.

Also, I fixed and merged #54 into this pull request.
