### PR TITLE
Change package name from "gl-rs" to "gl"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 
-name = "gl-rs"
+name = "gl"
 version = "0.0.1"
 authors = ["Brendan Zabarauskas <bjzaba@yahoo.com.au>",
         "Corey Richardson",


### PR DESCRIPTION
When the Cargo package manager gets the online package list component, the package name 
will be used as the identifier for the whole project.  Keeping "-rs" -- while useful for the github 
repository -- will be redundant in Cargo because all of the projects will obviously be rust projects.
