### PR TITLE
Remove deprecated .to_err_msg() call

### DIFF
--- a/src/gen/main.rs
+++ b/src/gen/main.rs
@@ -62,7 +62,7 @@ fn main() {
     let os_args = os::args().iter().map(|x| x.to_str()).collect::<Vec<String>>();
     let args = match getopts(os_args.as_slice(), opts) {
         Ok(a) => a,
-        Err(x) => fail!("Error: {}\n{}", x.to_err_msg(), usage("glrsgen", opts)),
+        Err(x) => fail!("Error: {}\n{}", x, usage("glrsgen", opts)),
     };
 
     if args.opt_present("help") {


### PR DESCRIPTION
I was getting an error when compiling (against master Rust):

```
src/gen/main.rs:65:42: 65:56 warning: use of deprecated item: use `Show` (`{}` format specifier), #[warn(deprecated)] on by default
src/gen/main.rs:65         Err(x) => fail!("Error: {}\n{}", x.to_err_msg(), usage("glrsgen", opts)),
                                                            ^~~~~~~~~~~~~~
```

Just using `x` fixed the problem.
