### PR TITLE
Add texture filtering extension

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,4 +35,4 @@ use std::mem;
 
 use self::types::*;
 
-generate_gl_bindings!("gl", "gl", "core", "4.3")
+generate_gl_bindings!("gl", "gl", "core", "4.3", "GL_EXT_texture_filter_anisotropic")


### PR DESCRIPTION
Any cargo project isn't allowed to configure the extensions used, so add this workaround
temporarily
