### PR TITLE
plugin = true for gl_generator

### DIFF
--- a/src/gl_generator/Cargo.toml
+++ b/src/gl_generator/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Brendan Zabarauskas <bjzaba@yahoo.com.au>",
 [[lib]]
 
 name = "gl_generator"
-crate_type = ["dylib"]
+plugin = true
 path = "src/gl_generator.rs"
 
 [dependencies.sax-rs]


### PR DESCRIPTION
In case of cross-compilation, `plugin = true` tells Cargo that `gl_generator` must always be compiled for the current host instead of target.

It also implicitely adds `crate_type = dylib`.
