### PR TITLE
Switch from sax-rs to rust-xml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: rust
 
 install:
-  # libxml2
-  - sudo apt-get install libxml2
   # glfw
   - sudo apt-get install libXxf86vm-dev
   - git clone https://github.com/glfw/glfw.git

--- a/src/gl_generator/Cargo.toml
+++ b/src/gl_generator/Cargo.toml
@@ -13,6 +13,6 @@ name = "gl_generator"
 plugin = true
 path = "src/lib.rs"
 
-[dependencies.sax-rs]
+[dependencies.rust-xml]
+git = "https://github.com/netvl/rust-xml"
 
-git = "https://github.com/bjz/sax-rs"


### PR DESCRIPTION
Remove `sax-rs` in favor of a pure Rust implementation named `rust-xml`.

Do not merge for the moment as this issue needs to be solved before it compiles: https://github.com/netvl/rust-xml/issues/3

The khronos XML file has an attribute that contains a `;` and that makes `rust-xml` trigger an error (see issue above). If I manually remove this `;` the library compiles and works perfectly.

Closes #111
This PR should not conflict with #119
