### PR TITLE
Add documentation and stability levels

### DIFF
--- a/src/gl/lib.rs
+++ b/src/gl/lib.rs
@@ -13,6 +13,58 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! # Usage
+//! 
+//! You can import the pointer style loader and type aliases like so:
+//! 
+//! ~~~rust
+//! extern crate gl;
+//! // include the OpenGL type aliases
+//! use gl::types::*;
+//! ~~~
+//! 
+//! You can load the function pointers into their respective function pointers
+//! using the `load_with` function. You must supply a loader function from your
+//! context library, This is how it would look using [glfw-rs]
+//! (https://github.com/bjz/glfw-rs):
+//! 
+//! ~~~rust
+//! // the supplied function must be of the type:
+//! // `&fn(symbol: &str) -> Option<extern "C" fn()>`
+//! gl::load_with(|s| glfw.get_proc_address(s));
+//! 
+//! // loading a specific function pointer
+//! gl::Viewport::load_with(|s| glfw.get_proc_address(s));
+//! ~~~
+//! 
+//! Calling a function that has not been loaded will result in a failure like:
+//! `fail!("gl::Viewport was not loaded")`, which aviods a segfault. This feature
+//! does not cause any run time overhead because the failing functions are
+//! assigned only when `load_with` is called.
+//! 
+//! ~~~rust
+//! // accessing an enum
+//! gl::RED_BITS;
+//! 
+//! // calling a function
+//! gl::DrawArrays(gl::TRIANGLES, 0, 3);
+//! 
+//! // functions that take pointers are unsafe
+//! unsafe { gl::ShaderSource(shader, 1, &c_str, std::ptr::null()) };
+//! ~~~
+//! 
+//! Each function pointer has an associated boolean value allowing you to
+//! check if a function has been loaded at run time. The function accesses a
+//! corresponding global boolean that is set when `load_with` is called, so there
+//! shouldn't be much overhead.
+//! 
+//! ~~~rust
+//! if gl::Viewport::is_loaded() {
+//!     // do something...
+//! }
+//! ~~~
+//!
+
 #![crate_name = "gl"]
 #![comment = "An OpenGL function loader."]
 #![license = "ASL2"]

--- a/src/gl_generator/lib.rs
+++ b/src/gl_generator/lib.rs
@@ -13,6 +13,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! # gl_generator
+//!
+//! `gl_generator` is an OpenGL bindings generator plugin. It defines a macro named
+//!  `generate_gl_bindings!` which can be used to generate all constants and functions of a
+//!  given OpenGL version.
+//!
+//! ## Example
+//!
+//! ```rust
+//! #[phase(plugin)]
+//! extern crate gl_generator;
+//! extern crate libc;
+//! 
+//! use std::mem;
+//! use self::types::*;
+//!
+//! generate_gl_bindings!("gl", "core", "4.5", "static", [ "GL_EXT_texture_filter_anisotropic" ])
+//! ```
+//!
+//! ## Parameters
+//!
+//! * API: Can be `gl`, `wgl`, `glx`, `egl`. Only `gl` is supported for the moment.
+//! * Profile: Can be `core` or `compatibility`. `core` will only include all functions supported
+//!    by the requested version it self, while `compatibility` will include all the functions from
+//!    previous versions as well.
+//! * Version: The requested OpenGL version in the format `x.x`.
+//! * Generator: Can be `static` or `struct`.
+//! * Extensions (optional): An array of extensions to include in the bindings.
+//! 
+
+
 #![crate_name = "gl_generator"]
 #![comment = "OpenGL function loader generator."]
 #![license = "ASL2"]

--- a/src/gl_generator/registry.rs
+++ b/src/gl_generator/registry.rs
@@ -13,8 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate xml;
+#![experimental]
+
 extern crate collections;
+extern crate xml;
 
 use self::collections::TreeSet;
 use std::cell::RefCell;

--- a/src/gl_generator/static_gen.rs
+++ b/src/gl_generator/static_gen.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![experimental]
+
 use registry::*;
 use ty;
 use common;
@@ -77,6 +79,7 @@ impl<'a, W: Writer> StaticGenerator<'a, W> {
             }
         };
 
+        self.write_line("#[stable]");
         self.write_line(format!("pub static {}: {} = {};", ident, ty, enm.value).as_slice())
     }
 
@@ -122,6 +125,7 @@ impl<'a, W: Writer> StaticGenerator<'a, W> {
     }
 
     fn write_type_aliases(&mut self) {
+        self.write_line("#[stable]");
         self.write_line("pub mod types {");
         self.incr_indent();
         self.write_line("");
@@ -183,7 +187,7 @@ impl<'a, W: Writer> StaticGenerator<'a, W> {
             self.write_line(
                 if c.is_safe {
                     format!(
-                        "#[inline] pub fn {name}({params}){return_suffix} {{ \
+                        "#[inline] #[unstable] pub fn {name}({params}){return_suffix} {{ \
                             unsafe {{ \
                                 mem::transmute::<_, extern \"system\" fn({types}){return_suffix}>\
                                     (storage::{name}.f)({idents}) \
@@ -197,7 +201,7 @@ impl<'a, W: Writer> StaticGenerator<'a, W> {
                     )
                 } else {
                     format!(
-                        "#[inline] pub unsafe fn {name}({typed_params}){return_suffix} {{ \
+                        "#[inline] #[unstable] pub unsafe fn {name}({typed_params}){return_suffix} {{ \
                             mem::transmute::<_, extern \"system\" fn({typed_params}) {return_suffix}>\
                                 (storage::{name}.f)({idents}) \
                         }}",
@@ -234,6 +238,7 @@ impl<'a, W: Writer> StaticGenerator<'a, W> {
     fn write_fn_mods(&mut self) {
         self.write_line("macro_rules! fn_mod {");
         self.write_line("    ($name:ident, $sym:expr) => {");
+        self.write_line("        #[unstable]");
         self.write_line("        pub mod $name {");
         self.write_line("            #[inline]");
         self.write_line("            pub fn is_loaded() -> bool { unsafe { ::storage::$name.is_loaded } }");
@@ -273,6 +278,7 @@ impl<'a, W: Writer> StaticGenerator<'a, W> {
         self.write_line("/// ~~~ignore");
         self.write_line("/// gl::load_with(|s| glfw.get_proc_address(s));");
         self.write_line("/// ~~~");
+        self.write_line("#[unstable]");
         self.write_line("pub fn load_with(loadfn: |symbol: &str| -> *const libc::c_void) {");
         self.incr_indent();
         for c in self.registry.cmd_iter() {

--- a/src/gl_generator/struct_gen.rs
+++ b/src/gl_generator/struct_gen.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![experimental]
+
 use registry::*;
 use ty;
 use common;
@@ -77,6 +79,7 @@ impl<'a, W: Writer> StructGenerator<'a, W> {
             }
         };
 
+        self.write_line("#[stable]");
         self.write_line(format!("pub static {}: {} = {};", ident, ty, enm.value).as_slice())
     }
 
@@ -186,6 +189,7 @@ impl<'a, W: Writer> StructGenerator<'a, W> {
     fn write_struct(&mut self) {
         let ns = self.ns;
         self.write_line("#[allow(uppercase_variables)]");
+        self.write_line("#[stable]");
         self.write_line(format!("pub struct {:c} {{", ns).as_slice());
         self.incr_indent();
         for c in self.registry.cmd_iter() {
@@ -209,6 +213,7 @@ impl<'a, W: Writer> StructGenerator<'a, W> {
         self.write_line("/// ~~~ignore");
         self.write_line("/// let gl = Gl::load_with(|s| glfw.get_proc_address(s));");
         self.write_line("/// ~~~");
+        self.write_line("#[unstable]");
         self.write_line(format!(
             "pub fn load_with(loadfn: |symbol: &str| -> *const ::libc::c_void) -> {:c} {{", ns
         ).as_slice());
@@ -231,7 +236,7 @@ impl<'a, W: Writer> StructGenerator<'a, W> {
             self.write_line(
                 if c.is_safe {
                     format!(
-                        "#[inline] pub fn {name}(&self, {params}){return_suffix} {{ \
+                        "#[inline] #[unstable] pub fn {name}(&self, {params}){return_suffix} {{ \
                             unsafe {{ \
                                 mem::transmute::<_, extern \"system\" fn({types}){return_suffix}>\
                                     (self.{name}.f)({idents}) \
@@ -245,7 +250,7 @@ impl<'a, W: Writer> StructGenerator<'a, W> {
                     )
                 } else {
                     format!(
-                        "#[inline] pub unsafe fn {name}(&self, {typed_params}){return_suffix} {{ \
+                        "#[inline] #[unstable] pub unsafe fn {name}(&self, {typed_params}){return_suffix} {{ \
                             mem::transmute::<_, extern \"system\" fn({typed_params}) {return_suffix}>\
                                 (self.{name}.f)({idents}) \
                         }}",

--- a/src/gl_generator/ty.rs
+++ b/src/gl_generator/ty.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![experimental]
+
 pub fn to_return_suffix(ty: &str) -> String {
     match ty {
         "::libc::c_void" | "c_void" | "VOID" | "GLvoid" => "".to_string(),


### PR DESCRIPTION
Add some top-level documentation for `gl` and `gl_generator`, and add stability level for API.

GL constants are marked as stable, gl functions and modules as unstable, modules in `gl_generator` as experimental.
