### PR TITLE
Improve gl_generator's API

### DIFF
--- a/src/gl/lib.rs
+++ b/src/gl/lib.rs
@@ -32,4 +32,4 @@ extern crate libc;
 use std::mem;
 use self::types::*;
 
-generate_gl_bindings!("gl", "gl", "core", "4.3", "static", "GL_EXT_texture_filter_anisotropic")
+generate_gl_bindings!("gl", "core", "4.3", "static", [ "GL_EXT_texture_filter_anisotropic" ])


### PR DESCRIPTION
Part of #130
- Remove the first parameter of `generate_gl_bindings` ; the namespace is deduced from the api. (for the moment it's always identical to the API, but maybe there could be special cases that I didn't think of)
- The last parameter is now a vector expression (and still optional)
