### PR TITLE
Fix rustdoc --test

### DIFF
--- a/src/gl_generator/static_gen.rs
+++ b/src/gl_generator/static_gen.rs
@@ -270,7 +270,7 @@ impl<'a, W: Writer> StaticGenerator<'a, W> {
         self.write_line("/// Load each OpenGL symbol using a custom load function. This allows for the");
         self.write_line("/// use of functions like `glfwGetProcAddress` or `SDL_GL_GetProcAddress`.");
         self.write_line("///");
-        self.write_line("/// ~~~rust");
+        self.write_line("/// ~~~ignore");
         self.write_line("/// gl::load_with(|s| glfw.get_proc_address(s));");
         self.write_line("/// ~~~");
         self.write_line("pub fn load_with(loadfn: |symbol: &str| -> *const libc::c_void) {");

--- a/src/gl_generator/struct_gen.rs
+++ b/src/gl_generator/struct_gen.rs
@@ -206,7 +206,7 @@ impl<'a, W: Writer> StructGenerator<'a, W> {
         self.write_line("/// Load each OpenGL symbol using a custom load function. This allows for the");
         self.write_line("/// use of functions like `glfwGetProcAddress` or `SDL_GL_GetProcAddress`.");
         self.write_line("///");
-        self.write_line("/// ~~~rust");
+        self.write_line("/// ~~~ignore");
         self.write_line("/// let gl = Gl::load_with(|s| glfw.get_proc_address(s));");
         self.write_line("/// ~~~");
         self.write_line(format!(


### PR DESCRIPTION
The latest Cargo nightlies include a `rustdoc --test` run. This fixed it.

At first I wanted to fix them by writing valid code and adding `no_run`.
But since the the generated code could be included inside the user's code (if he uses gl_generator as a stand-alone), this would force the user to add a dependency to `glfw`.
