### PR TITLE
Add crate khronos_api to store the GL API

### DIFF
--- a/src/gl_generator/Cargo.toml
+++ b/src/gl_generator/Cargo.toml
@@ -15,3 +15,6 @@ plugin = true
 
 [dependencies.rust-xml]
 git = "https://github.com/netvl/rust-xml"
+
+[dependencies.khronos_api]
+path = "../khronos_api"

--- a/src/khronos_api/Cargo.toml
+++ b/src/khronos_api/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+
+name = "khronos_api"
+version = "0.0.1"
+authors = []

--- a/src/khronos_api/src/lib.rs
+++ b/src/khronos_api/src/lib.rs
@@ -1,0 +1,13 @@
+//! This crates contains the sources of the official OpenGL repository.
+
+/// Content of the official `gl.xml` file.
+pub static GL_XML: &'static str = include_str!("../../../deps/khronos-api/gl.xml");
+
+/// Content of the official `egl.xml` file.
+pub static EGL_XML: &'static str = include_str!("../../../deps/khronos-api/egl.xml");
+
+/// Content of the official `wgl.xml` file.
+pub static WGL_XML: &'static str = include_str!("../../../deps/khronos-api/wgl.xml");
+
+/// Content of the official `glx.xml` file.
+pub static GLX_XML: &'static str = include_str!("../../../deps/khronos-api/glx.xml");


### PR DESCRIPTION
Part of #130

Fixes all the `couldn't open file 'deps/khronos-api/gl.xml'`-related issues.
