### PR TITLE
Implement generation for OpenGL ES

### DIFF
--- a/src/gl_generator/common.rs
+++ b/src/gl_generator/common.rs
@@ -66,7 +66,7 @@ pub fn gen_return_suffix(cmd: &Cmd) -> String {
 
 pub fn gen_symbol_name(ns: &Ns, cmd: &Cmd) -> String {
     (match *ns {
-        Gl => "gl",
+        Gl | Gles1 | Gles2 => "gl",
         Glx => "glx",
         Wgl => "wgl",
         Egl => "egl",

--- a/src/gl_generator/lib.rs
+++ b/src/gl_generator/lib.rs
@@ -34,7 +34,7 @@
 //!
 //! ## Parameters
 //!
-//! * API: Can be `gl`, `wgl`, `glx`, `egl`.
+//! * API: Can be `gl`, `gles1`, `gles2`, `wgl`, `glx`, `egl`.
 //! * Profile: Can be `core` or `compatibility`. `core` will only include all functions supported
 //!    by the requested version it self, while `compatibility` will include all the functions from
 //!    previous versions as well.
@@ -134,6 +134,8 @@ fn macro_handler(ecx: &mut ExtCtxt, span: Span, token_tree: &[TokenTree]) -> Box
         "glx" => (Glx, khronos_api::GLX_XML),
         "wgl" => (Wgl, khronos_api::WGL_XML),
         "egl" => (Egl, khronos_api::EGL_XML),
+        "gles1"  => (Gles1, khronos_api::GL_XML),
+        "gles2"  => (Gles2, khronos_api::GL_XML),
         ns => {
             ecx.span_err(span, format!("Unexpected opengl namespace '{}'", ns).as_slice());
             return DummyResult::any(span)

--- a/src/gl_generator/registry.rs
+++ b/src/gl_generator/registry.rs
@@ -27,7 +27,7 @@ use std::slice::Items;
 
 use self::xml::reader::events;
 
-pub enum Ns { Gl, Glx, Wgl, Egl }
+pub enum Ns { Gl, Glx, Wgl, Egl, Gles1, Gles2 }
 
 impl FromStr for Ns {
     fn from_str(s: &str) -> Option<Ns> {
@@ -36,6 +36,8 @@ impl FromStr for Ns {
             "glx" => Some(Glx),
             "wgl" => Some(Wgl),
             "egl" => Some(Egl),
+            "gles1" => Some(Gles1),
+            "gles2" => Some(Gles2),
             _     => None,
         }
     }
@@ -48,6 +50,8 @@ impl fmt::Show for Ns {
             Glx => write!(fmt, "glx"),
             Wgl => write!(fmt, "wgl"),
             Egl => write!(fmt, "egl"),
+            Gles1 => write!(fmt, "gles1"),
+            Gles2 => write!(fmt, "gles2"),
         }
     }
 }
@@ -59,6 +63,8 @@ impl fmt::Char for Ns {
             Glx => write!(fmt, "Glx"),
             Wgl => write!(fmt, "Wgl"),
             Egl => write!(fmt, "Egl"),
+            Gles1 => write!(fmt, "Gles1"),
+            Gles2 => write!(fmt, "Gles2"),
         }
     }
 }
@@ -69,7 +75,7 @@ fn trim_str<'a>(s: &'a str, trim: &str) -> &'a str {
 
 fn trim_enum_prefix<'a>(ident: &'a str, ns: Ns) -> &'a str {
     match ns {
-        Gl => trim_str(ident, "GL_"),
+        Gl | Gles1 | Gles2 => trim_str(ident, "GL_"),
         Glx => trim_str(ident, "GLX_"),
         Wgl =>  trim_str(ident, "WGL_"),
         Egl =>  trim_str(ident, "EGL_"),
@@ -78,7 +84,7 @@ fn trim_enum_prefix<'a>(ident: &'a str, ns: Ns) -> &'a str {
 
 fn trim_cmd_prefix<'a>(ident: &'a str, ns: Ns) -> &'a str {
     match ns {
-        Gl => trim_str(ident, "gl"),
+        Gl | Gles1 | Gles2 => trim_str(ident, "gl"),
         Glx => trim_str(ident, "glX"),
         Wgl =>  trim_str(ident, "wgl"),
         Egl =>  trim_str(ident, "egl"),

--- a/src/gl_generator/static_gen.rs
+++ b/src/gl_generator/static_gen.rs
@@ -130,7 +130,7 @@ impl<'a, W: Writer> StaticGenerator<'a, W> {
         self.incr_indent();
         self.write_line("");
         match self.ns {
-            Gl => {
+            Gl | Gles1 | Gles2 => {
                 for alias in ty::GL_ALIASES.iter() {
                     self.write_line("#[allow(non_camel_case_types)]");
                     self.write_line("#[allow(non_snake_case)]");

--- a/src/gl_generator/struct_gen.rs
+++ b/src/gl_generator/struct_gen.rs
@@ -130,7 +130,7 @@ impl<'a, W: Writer> StructGenerator<'a, W> {
         self.incr_indent();
         self.write_line("");
         match self.ns {
-            Gl => {
+            Gl | Gles1 | Gles2 => {
                 for alias in ty::GL_ALIASES.iter() {
                     self.write_line("#[allow(non_camel_case_types)]");
                     self.write_line("#[allow(non_snake_case)]");

--- a/tests/gles.rs
+++ b/tests/gles.rs
@@ -1,0 +1,18 @@
+#![feature(phase)]
+
+#[phase(plugin)]
+extern crate gl_generator;
+
+extern crate libc;
+
+mod gl {
+    generate_gl_bindings!("gles2", "core", "3.1", "static")
+}
+
+#[test]
+#[ignore]
+fn test() {
+    gl::Clear(gl::COLOR_BUFFER_BIT);
+    let _: libc::c_uint = gl::CreateProgram();
+    gl::CompileShader(5);
+}

--- a/tests/no_warning.rs
+++ b/tests/no_warning.rs
@@ -73,3 +73,19 @@ mod egl_struct {
 
     generate_gl_bindings!("egl", "core", "1.5", "struct")
 }
+
+mod gles1_static {
+    generate_gl_bindings!("gles1", "core", "1.1", "static")
+}
+
+mod gles1_struct {
+    generate_gl_bindings!("gles1", "core", "1.1", "struct")
+}
+
+mod gles2_static {
+    generate_gl_bindings!("gles2", "core", "3.1", "static")
+}
+
+mod gles2_struct {
+    generate_gl_bindings!("gles2", "core", "3.1", "struct")
+}


### PR DESCRIPTION
Based upon #157

Close #156

If you know a function or an enum that exists in OpenGL ES but not in OpenGL, please add it in the `gles.rs` test.
Note that the contrary works, ie. functions/enums that don't exist in OpenGL ES are not generated, but obviously I can't add a test for this.
