### PR TITLE
Rename "static" generator to "global"

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Then use it like this:
 extern crate gl_generator;
 
 mod gl {
-    generate_gl_bindings!("gl", "core", "4.5", "static")
+    generate_gl_bindings!("gl", "core", "4.5", "global")
 }
 ```
 
@@ -100,23 +100,23 @@ The parameters are the following:
  * Profile: Can be `core` or `compatibility`.
  * Version: The requested version of OpenGL, WGL, GLX or EGL in the format
     `x.x`.
- * Generator: Can be `static` or `struct` (more informations below).
+ * Generator: Can be `global` or `struct` (more informations below).
  * Extensions (optional): An array of extensions to include in the bindings.
-    For example: `generate_gl_bindings!("gl", "core", "4.5", "static",
+    For example: `generate_gl_bindings!("gl", "core", "4.5", "global",
     [ "GL_EXT_texture_filter_anisotropic" ])`
 
-### Static generator
+### Global generator
 
-The static generator is the one used by default by the `gl` crate. See above
+The global generator is the one used by default by the `gl` crate. See above
 for more details.
 
 ### Struct generator
 
-The struct generator is a cleaner alternative to the static generator.
+The struct generator is a cleaner alternative to the global generator.
 
 The main difference is that you must call `gl::Gl::load_with` instead of
 `gl::load_with`, and this functions returns a struct of type `Gl`. The OpenGL
-functions are not global functions but member functions in this `Gl` struct.
+functions are not static functions but member functions in this `Gl` struct.
 
 The enumerations and types are still static and available in a similar way as
-in the static generator.
+in the global generator.

--- a/src/gl/lib.rs
+++ b/src/gl/lib.rs
@@ -85,4 +85,4 @@
 #[phase(plugin)]
 extern crate gl_generator;
 
-generate_gl_bindings!("gl", "core", "4.5", "static", [ "GL_EXT_texture_filter_anisotropic" ])
+generate_gl_bindings!("gl", "core", "4.5", "global", [ "GL_EXT_texture_filter_anisotropic" ])

--- a/src/gl_generator/global_gen.rs
+++ b/src/gl_generator/global_gen.rs
@@ -22,16 +22,16 @@ use std::io::Writer;
 
 static TAB_WIDTH: uint = 4;
 
-pub struct StaticGenerator<'a, W: 'a> {
+pub struct GlobalGenerator<'a, W: 'a> {
     ns: Ns,
     writer: &'a mut W,
     registry: &'a Registry,
     indent: uint,
 }
 
-impl<'a, W: Writer> StaticGenerator<'a, W> {
-    fn new<'a>(writer: &'a mut W, registry: &'a Registry, ns: Ns) -> StaticGenerator<'a, W> {
-        StaticGenerator {
+impl<'a, W: Writer> GlobalGenerator<'a, W> {
+    fn new<'a>(writer: &'a mut W, registry: &'a Registry, ns: Ns) -> GlobalGenerator<'a, W> {
+        GlobalGenerator {
             ns: ns,
             writer: writer,
             registry: registry,
@@ -349,7 +349,7 @@ impl<'a, W: Writer> StaticGenerator<'a, W> {
     }
 
     pub fn write(writer: &mut W, registry: &Registry, ns: Ns) {
-        let mut gen = StaticGenerator::new(writer, registry, ns);
+        let mut gen = GlobalGenerator::new(writer, registry, ns);
 
         // header with imports
         gen.write_header();

--- a/tests/generators_symbols.rs
+++ b/tests/generators_symbols.rs
@@ -6,19 +6,19 @@ extern crate gl_generator;
 extern crate libc;
 
 mod gl {
-    generate_gl_bindings!("gl", "core", "4.5", "static")
+    generate_gl_bindings!("gl", "core", "4.5", "global")
 }
 
 mod gles {
-    generate_gl_bindings!("gles2", "core", "3.1", "static")
+    generate_gl_bindings!("gles2", "core", "3.1", "global")
 }
 
 mod glx {
-    generate_gl_bindings!("glx", "core", "1.4", "static")
+    generate_gl_bindings!("glx", "core", "1.4", "global")
 }
 
 mod wgl {
-    generate_gl_bindings!("wgl", "core", "1.0", "static")
+    generate_gl_bindings!("wgl", "core", "1.0", "global")
 }
 
 mod egl {
@@ -37,7 +37,7 @@ mod egl {
     pub type NativePixmapType = *const libc::c_void;
     pub type NativeWindowType = *const libc::c_void;
 
-    generate_gl_bindings!("egl", "core", "1.5", "static")
+    generate_gl_bindings!("egl", "core", "1.5", "global")
 }
 
 #[test]

--- a/tests/no_warning.rs
+++ b/tests/no_warning.rs
@@ -11,7 +11,7 @@ extern crate gl_generator;
 extern crate libc;
 
 mod gl_static {
-    generate_gl_bindings!("gl", "core", "4.5", "static")
+    generate_gl_bindings!("gl", "core", "4.5", "global")
 }
 
 mod gl_struct {
@@ -19,7 +19,7 @@ mod gl_struct {
 }
 
 mod glx_static {
-    generate_gl_bindings!("glx", "core", "1.4", "static")
+    generate_gl_bindings!("glx", "core", "1.4", "global")
 }
 
 mod glx_struct {
@@ -27,7 +27,7 @@ mod glx_struct {
 }
 
 mod wgl_static {
-    generate_gl_bindings!("wgl", "core", "1.0", "static")
+    generate_gl_bindings!("wgl", "core", "1.0", "global")
 }
 
 mod wgl_struct {
@@ -51,7 +51,7 @@ mod egl_static {
     pub type NativePixmapType = *const libc::c_void;
     pub type NativeWindowType = *const libc::c_void;
 
-    generate_gl_bindings!("egl", "core", "1.5", "static")
+    generate_gl_bindings!("egl", "core", "1.5", "global")
 }
 
 mod egl_struct {
@@ -75,7 +75,7 @@ mod egl_struct {
 }
 
 mod gles1_static {
-    generate_gl_bindings!("gles1", "core", "1.1", "static")
+    generate_gl_bindings!("gles1", "core", "1.1", "global")
 }
 
 mod gles1_struct {
@@ -83,7 +83,7 @@ mod gles1_struct {
 }
 
 mod gles2_static {
-    generate_gl_bindings!("gles2", "core", "3.1", "static")
+    generate_gl_bindings!("gles2", "core", "3.1", "global")
 }
 
 mod gles2_struct {


### PR DESCRIPTION
First step for #163

I don't think that a lot of code uses the macro for the moment, and even less for the "static" generator, so this shouldn't be too big of a change.
