### PR TITLE
Use include_bin instead of include_str in khronos_api

### DIFF
--- a/src/gl_generator/lib.rs
+++ b/src/gl_generator/lib.rs
@@ -132,7 +132,7 @@ fn macro_handler(ecx: &mut ExtCtxt, span: Span, token_tree: &[TokenTree]) -> Box
         use std::task;
 
         let result = task::try(proc() {
-            let reader = BufReader::new(source.as_bytes());
+            let reader = BufReader::new(source);
             Registry::from_xml(reader, ns, filter)
         });
 

--- a/src/khronos_api/src/lib.rs
+++ b/src/khronos_api/src/lib.rs
@@ -1,13 +1,13 @@
 //! This crates contains the sources of the official OpenGL repository.
 
 /// Content of the official `gl.xml` file.
-pub static GL_XML: &'static str = include_str!("../../../deps/khronos-api/gl.xml");
+pub static GL_XML: &'static [u8] = include_bin!("../../../deps/khronos-api/gl.xml");
 
 /// Content of the official `egl.xml` file.
-pub static EGL_XML: &'static str = include_str!("../../../deps/khronos-api/egl.xml");
+pub static EGL_XML: &'static [u8] = include_bin!("../../../deps/khronos-api/egl.xml");
 
 /// Content of the official `wgl.xml` file.
-pub static WGL_XML: &'static str = include_str!("../../../deps/khronos-api/wgl.xml");
+pub static WGL_XML: &'static [u8] = include_bin!("../../../deps/khronos-api/wgl.xml");
 
 /// Content of the official `glx.xml` file.
-pub static GLX_XML: &'static str = include_str!("../../../deps/khronos-api/glx.xml");
+pub static GLX_XML: &'static [u8] = include_bin!("../../../deps/khronos-api/glx.xml");


### PR DESCRIPTION
Technically the XML files are not necessarly UTF-8, so we should use `include_bin` instead of `include_str`.
