### PR TITLE
[Do not merge] Update dependencies to use the central repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,16 @@
 [package]
 
 name = "gl"
-version = "0.0.1"
+version = "0.0.2-pre"
 authors = ["Brendan Zabarauskas <bjzaba@yahoo.com.au>",
         "Corey Richardson",
         "Arseny Kapoulkine"
 ]
+description = "Bindings for the latest core version of OpenGL."
+repository = "https://github.com/bjz/gl-rs"
+keywords = ["opengl"]
+readme = "README.md"
+license = "Apache-2.0"
 
 [lib]
 name = "gl"
@@ -13,6 +18,7 @@ path = "src/gl/lib.rs"
 
 [dependencies.gl_generator]
 path = "src/gl_generator"
+version = "*"
 
-[dev-dependencies.glfw]
-git = "https://github.com/bjz/glfw-rs"
+[dev-dependencies]
+glfw = "*"

--- a/src/gl_common/Cargo.toml
+++ b/src/gl_common/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "gl_common"
-version = "0.0.1"
+version = "0.0.3-pre"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
-
+repository = "https://github.com/bjz/gl-rs"
+keywords = ["opengl"]
+license = "Apache-2.0"

--- a/src/gl_generator/Cargo.toml
+++ b/src/gl_generator/Cargo.toml
@@ -1,11 +1,15 @@
 [package]
 
 name = "gl_generator"
-version = "0.0.1"
+version = "0.0.4-pre"
 authors = ["Brendan Zabarauskas <bjzaba@yahoo.com.au>",
         "Corey Richardson",
         "Arseny Kapoulkine"
 ]
+description = "Bindings generator for all versions and extensions of OpenGL, OpenGL ES, WGL, GLX or EGL."
+repository = "https://github.com/bjz/gl-rs"
+keywords = ["opengl"]
+license = "Apache-2.0"
 
 [lib]
 
@@ -13,11 +17,13 @@ name = "gl_generator"
 path = "lib.rs"
 plugin = true
 
+[dependencies]
+rust-xml = "*"
+
 [dependencies.gl_common]
 path = "../gl_common"
-
-[dependencies.rust-xml]
-git = "https://github.com/netvl/rust-xml"
+version = "*"
 
 [dependencies.khronos_api]
 path = "../khronos_api"
+version = "*"

--- a/src/khronos_api/Cargo.toml
+++ b/src/khronos_api/Cargo.toml
@@ -1,5 +1,9 @@
 [package]
 
 name = "khronos_api"
-version = "0.0.2"
+version = "0.0.4-pre"
 authors = []
+description = "Contains the XML files that describe the official Khronos APIs."
+repository = "https://github.com/bjz/gl-rs"
+keywords = ["opengl"]
+license = "Apache-2.0"


### PR DESCRIPTION
This is the version of the source code that is currently uploaded on crates.io's alpha, except that the examples and the glfw dependency are removed.
This PR should be merged when the website is released publicly.
