### PR TITLE
Fix for std::from_str::FromStr refactoring

### DIFF
--- a/src/gl_generator/registry.rs
+++ b/src/gl_generator/registry.rs
@@ -24,7 +24,7 @@ use std::cell::RefCell;
 use std::collections::HashSet;
 use std::collections::HashMap;
 use std::fmt;
-use std::from_str::FromStr;
+use std::str::FromStr;
 use std::slice::Items;
 
 use self::xml::reader::events;


### PR DESCRIPTION
In Rust commit [29bc9c632](https://github.com/rust-lang/rust/commit/29bc9c632), `std::from_str::FromStr` was moved to `std::str::FromStr`.
