### PR TITLE
Update for rustc

### DIFF
--- a/src/gl_generator/generators/struct_gen.rs
+++ b/src/gl_generator/generators/struct_gen.rs
@@ -226,8 +226,8 @@ fn write_impl(ecx: &ExtCtxt, registry: &Registry, ns: &Ns) -> P<ast::Item> {
                 name = c.proto.ident,
                 symbol = super::gen_symbol_name(ns, c.proto.ident.as_slice()),
                 fb = match fallbacks {
-                    Some(fallbacks) => format!("[{}]", fallbacks.iter().map(|name| format!("\"{}\"", name)).collect::<Vec<_>>().connect(", ")),
-                    None => format!("[]")
+                    Some(fallbacks) => format!("&[{}]", fallbacks.iter().map(|name| format!("\"{}\"", name)).collect::<Vec<_>>().connect(", ")),
+                    None => format!("&[]")
                 },
             )
         }).collect::<Vec<String>>().connect("\n"),


### PR DESCRIPTION
`[a, b, c, ...]` no longer coerces to `&[T]`
