### PR TITLE
Remove usage of regex

### DIFF
--- a/src/gl_generator/lib.rs
+++ b/src/gl_generator/lib.rs
@@ -86,11 +86,7 @@
 #[phase(plugin, link)]
 extern crate log;
 
-#[phase(plugin)]
-extern crate regex_macros;
-
 extern crate khronos_api;
-extern crate regex;
 extern crate rustc;
 extern crate syntax;
 


### PR DESCRIPTION
These regex warnings are not going to be fixed anytime soon and are killing the whole gamedev thing of Rust.

Close #235 
