### PR TITLE
Fix *mut libc::c_void being incorrectly replaced by ()

### DIFF
--- a/src/gl_generator/generators/mod.rs
+++ b/src/gl_generator/generators/mod.rs
@@ -143,8 +143,8 @@ pub fn gen_return_type(cmd: &Cmd) -> String {
     // turn the return type into a Rust type
     let ty = ty::to_rust_ty(cmd.proto.ty.as_slice());
 
-    // ... but there is one more step: if the Rust type ends with `c_void`, we replace it with `()`
-    if ty.ends_with("c_void") {
+    // ... but there is one more step: if the Rust type is `c_void`, we replace it with `()`
+    if ty == "__gl_imports::libc::c_void" {
         return "()".to_string();
     }
 

--- a/tests/generators_symbols.rs
+++ b/tests/generators_symbols.rs
@@ -16,6 +16,8 @@ fn test_gl() { unsafe {
 
     gl::GetActiveUniformBlockiv(0, 0, gl::UNIFORM_BLOCK_REFERENCED_BY_GEOMETRY_SHADER,
         std::ptr::null_mut());
+
+    let _: *mut libc::c_void = gl::MapBuffer(0, 0);
 }}
 
 #[test]


### PR DESCRIPTION
`glMapBuffer` returns `()` instead of `*mut libc::c_void`. This fixes it.
