### PR TITLE
Use include_bytes! instead of include_bin!

### DIFF
--- a/src/khronos_api/src/lib.rs
+++ b/src/khronos_api/src/lib.rs
@@ -1,13 +1,13 @@
 //! This crates contains the sources of the official OpenGL repository.
 
 /// Content of the official `gl.xml` file.
-pub static GL_XML: &'static [u8] = include_bin!("../api/gl.xml");
+pub static GL_XML: &'static [u8] = include_bytes!("../api/gl.xml");
 
 /// Content of the official `egl.xml` file.
-pub static EGL_XML: &'static [u8] = include_bin!("../api/egl.xml");
+pub static EGL_XML: &'static [u8] = include_bytes!("../api/egl.xml");
 
 /// Content of the official `wgl.xml` file.
-pub static WGL_XML: &'static [u8] = include_bin!("../api/wgl.xml");
+pub static WGL_XML: &'static [u8] = include_bytes!("../api/wgl.xml");
 
 /// Content of the official `glx.xml` file.
-pub static GLX_XML: &'static [u8] = include_bin!("../api/glx.xml");
+pub static GLX_XML: &'static [u8] = include_bytes!("../api/glx.xml");


### PR DESCRIPTION
Fixes warning due to `include_bin!` being deprecated in favor of `include_bytes!`
