### PR TITLE
README changes to remove generator macro example

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,11 +117,7 @@ fn main() {
 Then use it like this:
 
 ~~~rust
-#![feature(phase)]
 #![feature(globs)]
-
-#[phase(plugin)]
-extern crate gl_generator;
 
 use gles::types::*;
 


### PR DESCRIPTION
Changed README example using the generate_gl_bindings! macro to use the build dependency and build.rs script.
