### PR TITLE
Fix bazel build with changing path in include_bytes.

### DIFF
--- a/khronos_api/Cargo.toml
+++ b/khronos_api/Cargo.toml
@@ -13,6 +13,7 @@ documentation = "https://docs.rs/khronos_api"
 homepage = "https://github.com/brendanzab/gl-rs/"
 repository = "https://github.com/brendanzab/gl-rs/"
 readme = "README.md"
+edition = "2018"
 
 # Only include what we need here. The git submodules are quite large, and would
 # exceed the maximimum crate size if we didn't do this


### PR DESCRIPTION
This works well with both cargo and bazel.

Take a look at https://github.com/google/cargo-raze/issues/41#issuecomment-868860920 for details.