### PR TITLE
Fix build with Bazel

### DIFF
--- a/khronos_api/build.rs
+++ b/khronos_api/build.rs
@@ -29,7 +29,8 @@ fn main() {
     // The absolute path is needed, because we don't know where the output
     // directory will be, and `include_bytes!(..)` resolves paths relative to the
     // containing file.
-    let root = env::current_dir().unwrap().join("api_webgl/extensions");
+    let cargo_manifest_dir = PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").unwrap());
+    let root = cargo_manifest_dir.join("api_webgl/extensions");
 
     // Generate a slice literal, looking like this:
     // `&[&*include_bytes!(..), &*include_bytes!(..), ..]`
@@ -53,7 +54,7 @@ fn main() {
             let ext_path = path.join("extension.xml");
             if ext_path.is_file() {
                 // Include the XML file, making sure to use an absolute path.
-                writeln!(file, "&*include_bytes!({:?}),", ext_path.to_str().unwrap()).unwrap();
+                writeln!(file, "&*include_bytes!(concat!(env!(\"CARGO_MANIFEST_DIR\"), \"/\", {:?})),", ext_path.strip_prefix(cargo_manifest_dir.clone()).unwrap().to_str().unwrap()).unwrap();
             }
         }
     }


### PR DESCRIPTION
When building Rust applications with Bazel instead of cargo, typically a sandbox is in place, where each process invocation (rustc, build.rs program, etc.) runs in its own "root", where the view on the filesystem is the same, but the absolute paths are different. As a consequence, CARGO_MANIFEST_DIR differs between the invocation of build.rs and rustc.

That means that absolute paths in the generated webgl_exts.rs don't work. Fortunately, the source files are relative to the CARGO_MANIFEST_DIR, which, while changing between invocations, remains valid.